### PR TITLE
This fixes the "bermuda rectanble" bug

### DIFF
--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -24,11 +24,18 @@
                 "Place": function(){
                     document.getElementById("rowSelec").value = row;
                     document.getElementById("colSelec").value = col;
-                    placeShip()},
+                    placeShip();
+                    $( this ).dialog( "close" )},
                 "Fire": function(){
                     document.getElementById("colFire").value = row;
                     document.getElementById("rowFire").value = col;
-                    fire()},
+                    fire();
+                    $( this ).dialog( "close" )},
+                "Scan": function(){
+                    document.getElementById("colScan").value = row;
+                    document.getElementById("rowScan").value = col;
+                    scan();
+                    $( this ).dialog( "close" )},
                 "No!": function(){
                     cel.style.backgroundColor = oldColor,
                         $( this ).dialog( "close" );

--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -138,7 +138,7 @@ function selecVert() {
                 <td id="1_4"  class="{{1_4}} loc" onclick="click_control(this,1,4)"></td>
                 <td id="1_5"  class="{{1_5}} loc" onclick="click_control(this,1,5)"></td>
                 <td id="1_6"  class="{{1_6}} loc" onclick="click_control(this,1,6)"></td>
-                <td id="1_6"  class="{{1_7}} loc" onclick="click_control(this,1,7)"></td>
+                <td id="1_7"  class="{{1_7}} loc" onclick="click_control(this,1,7)"></td>
                 <td id="1_8"  class="{{1_8}} loc" onclick="click_control(this,1,8)"></td>
                 <td id="1_9"  class="{{1_9}} loc" onclick="click_control(this,1,9)"></td>
                 <td id="1_10"  class="{{1_10}} loc" onclick="click_control(this,1,10)"></td>
@@ -150,7 +150,7 @@ function selecVert() {
                 <td id="2_4"  class="{{2_4}} loc" onclick="click_control(this,2,4)"></td>
                 <td id="2_5"  class="{{2_5}} loc" onclick="click_control(this,2,5)"></td>
                 <td id="2_6"  class="{{2_6}} loc" onclick="click_control(this,2,6)"></td>
-                <td id="2_6"  class="{{2_7}} loc" onclick="click_control(this,2,7)"></td>
+                <td id="2_7"  class="{{2_7}} loc" onclick="click_control(this,2,7)"></td>
                 <td id="2_8"  class="{{2_8}} loc" onclick="click_control(this,2,8)"></td>
                 <td id="2_9"  class="{{2_9}} loc" onclick="click_control(this,2,9)"></td>
                 <td id="2_10"  class="{{2_10}} loc" onclick="click_control(this,2,10)"></td>
@@ -162,7 +162,7 @@ function selecVert() {
                 <td id="3_4"  class="{{3_4}} loc" onclick="click_control(this,3,4)"></td>
                 <td id="3_5"  class="{{3_5}} loc" onclick="click_control(this,3,5)"></td>
                 <td id="3_6"  class="{{3_6}} loc" onclick="click_control(this,3,6)"></td>
-                <td id="3_6"  class="{{3_7}} loc" onclick="click_control(this,3,7)"></td>
+                <td id="3_7"  class="{{3_7}} loc" onclick="click_control(this,3,7)"></td>
                 <td id="3_8"  class="{{3_8}} loc" onclick="click_control(this,3,8)"></td>
                 <td id="3_9"  class="{{3_9}} loc" onclick="click_control(this,3,9)"></td>
                 <td id="3_10" class="{{3_10}} loc" onclick="click_control(this,3,10)"></td>
@@ -174,7 +174,7 @@ function selecVert() {
                 <td id="4_4" class="{{4_4}} loc" onclick="click_control(this,4,4)"></td>
                 <td id="4_5" class="{{4_5}} loc" onclick="click_control(this,4,5)"></td>
                 <td id="4_6" class="{{4_6}} loc" onclick="click_control(this,4,6)"></td>
-                <td id="4_6" class="{{4_7}} loc" onclick="click_control(this,4,7)"></td>
+                <td id="4_7" class="{{4_7}} loc" onclick="click_control(this,4,7)"></td>
                 <td id="4_8"  class="{{4_8}} loc" onclick="click_control(this,4,8)"></td>
                 <td id="4_9" class="{{4_9}} loc" onclick="click_control(this,4,9)"></td>
                 <td id="4_10"  class="{{4_10}} loc" onclick="click_control(this,4,10)"></td>
@@ -186,7 +186,7 @@ function selecVert() {
                 <td id="5_4" class="{{5_4}} loc" onclick="click_control(this,5,4)"></td>
                 <td id="5_5" class="{{5_5}} loc" onclick="click_control(this,5,5)"></td>
                 <td id="5_6" class="{{5_6}} loc" onclick="click_control(this,5,6)"></td>
-                <td id="5_6" class="{{5_7}} loc" onclick="click_control(this,5,7)"></td>
+                <td id="5_7" class="{{5_7}} loc" onclick="click_control(this,5,7)"></td>
                 <td id="5_8" class="{{5_8}} loc" onclick="click_control(this,5,8)"></td>
                 <td id="5_9" class="{{5_9}} loc" onclick="click_control(this,5,10)"></td>
                 <td id="5_10" class="{{5_10}} loc" onclick="click_control(this,5,10)"></td>
@@ -198,7 +198,7 @@ function selecVert() {
                 <td id="6_4" class="{{6_4}} loc" onclick="click_control(this,6,4)"></td>
                 <td id="6_5" class="{{6_5}} loc" onclick="click_control(this,6,5)"></td>
                 <td id="6_6" class="{{6_6}} loc" onclick="click_control(this,6,6)"></td>
-                <td id="6_6" class="{{6_7}} loc" onclick="click_control(this,6,7)"></td>
+                <td id="6_7" class="{{6_7}} loc" onclick="click_control(this,6,7)"></td>
                 <td id="6_8" class="{{6_8}} loc" onclick="click_control(this,6,8)"></td>
                 <td id="6_9" class="{{6_9}} loc" onclick="click_control(this,6,10)"></td>
                 <td id="6_10" class="{{6_10}} loc" onclick="click_control(this,6,10)"></td>
@@ -210,7 +210,7 @@ function selecVert() {
                 <td id="7_4" class="{{7_4}} loc" onclick="click_control(this,7,4)"></td>
                 <td id="7_5" class="{{7_5}} loc" onclick="click_control(this,7,5)"></td>
                 <td id="7_6" class="{{7_6}} loc" onclick="click_control(this,7,6)"></td>
-                <td id="7_6" class="{{7_7}} loc" onclick="click_control(this,7,7)"></td>
+                <td id="7_7" class="{{7_7}} loc" onclick="click_control(this,7,7)"></td>
                 <td id="7_8" class="{{7_8}} loc" onclick="click_control(this,7,8)"></td>
                 <td id="7_9" class="{{7_9}} loc" onclick="click_control(this,7,10)"></td>
                 <td id="7_10" class="{{7_10}} loc" onclick="click_control(this,7,10)"></td>
@@ -222,7 +222,7 @@ function selecVert() {
                 <td id="8_4" class="{{7_4}} loc" onclick="click_control(this,8,4)"></td>
                 <td id="8_5" class="{{7_5}} loc" onclick="click_control(this,8,5)"></td>
                 <td id="8_6" class="{{7_6}} loc" onclick="click_control(this,8,6)"></td>
-                <td id="8_6" class="{{7_7}} loc" onclick="click_control(this,8,7)"></td>
+                <td id="8_7" class="{{7_7}} loc" onclick="click_control(this,8,7)"></td>
                 <td id="8_8" class="{{7_8}} loc" onclick="click_control(this,8,8)"></td>
                 <td id="8_9" class="{{7_9}} loc" onclick="click_control(this,8,10)"></td>
                 <td id="8_10" class="{{7_10}} loc" onclick="click_control(this,8,10)"></td>
@@ -234,7 +234,7 @@ function selecVert() {
                 <td id="9_4" class="{{7_4}} loc" onclick="click_control(this,9,4)"></td>
                 <td id="9_5" class="{{7_5}} loc" onclick="click_control(this,9,5)"></td>
                 <td id="9_6" class="{{7_6}} loc" onclick="click_control(this,9,6)"></td>
-                <td id="9_6" class="{{7_7}} loc" onclick="click_control(this,9,7)"></td>
+                <td id="9_7" class="{{7_7}} loc" onclick="click_control(this,9,7)"></td>
                 <td id="9_8" class="{{7_8}} loc" onclick="click_control(this,9,8)"></td>
                 <td id="9_9" class="{{7_9}} loc" onclick="click_control(this,9,9)"></td>
                 <td id="9_10" class="{{7_10}} loc" onclick="click_control(this,9,10)"></td>
@@ -246,7 +246,7 @@ function selecVert() {
                 <td id="10_4" class="{{7_4}} loc" onclick="click_control(this,10,4)"></td>
                 <td id="10_5" class="{{7_5}} loc" onclick="click_control(this,10,5)"></td>
                 <td id="10_6" class="{{7_6}} loc" onclick="click_control(this,10,6)"></td>
-                <td id="10_6" class="{{7_7}} loc" onclick="click_control(this,10,7)"></td>
+                <td id="10_7" class="{{7_7}} loc" onclick="click_control(this,10,7)"></td>
                 <td id="10_8" class="{{7_8}} loc" onclick="click_control(this,10,8)"></td>
                 <td id="10_9" class="{{7_9}} loc" onclick="click_control(this,10,9)"></td>
                 <td id="10_10" class="{{7_10}} loc" onclick="click_control(this,10,10)"></td>
@@ -265,7 +265,7 @@ function selecVert() {
                 <td id="1_4"  class="{{1_4}} loc" onclick="click_control(this,1,4)"></td>
                 <td id="1_5"  class="{{1_5}} loc" onclick="click_control(this,1,5)"></td>
                 <td id="1_6"  class="{{1_6}} loc" onclick="click_control(this,1,6)"></td>
-                <td id="1_6"  class="{{1_7}} loc" onclick="click_control(this,1,7)"></td>
+                <td id="1_7"  class="{{1_7}} loc" onclick="click_control(this,1,7)"></td>
                 <td id="1_8"  class="{{1_8}} loc" onclick="click_control(this,1,8)"></td>
                 <td id="1_9"  class="{{1_9}} loc" onclick="click_control(this,1,9)"></td>
                 <td id="1_10"  class="{{1_10}} loc" onclick="click_control(this,1,10)"></td>
@@ -277,7 +277,7 @@ function selecVert() {
                 <td id="2_4"  class="{{2_4}} loc" onclick="click_control(this,2,4)"></td>
                 <td id="2_5"  class="{{2_5}} loc" onclick="click_control(this,2,5)"></td>
                 <td id="2_6"  class="{{2_6}} loc" onclick="click_control(this,2,6)"></td>
-                <td id="2_6"  class="{{2_7}} loc" onclick="click_control(this,2,7)"></td>
+                <td id="2_7"  class="{{2_7}} loc" onclick="click_control(this,2,7)"></td>
                 <td id="2_8"  class="{{2_8}} loc" onclick="click_control(this,2,8)"></td>
                 <td id="2_9"  class="{{2_9}} loc" onclick="click_control(this,2,9)"></td>
                 <td id="2_10"  class="{{2_10}} loc" onclick="click_control(this,2,10)"></td>
@@ -289,7 +289,7 @@ function selecVert() {
                 <td id="3_4"  class="{{3_4}} loc" onclick="click_control(this,3,4)"></td>
                 <td id="3_5"  class="{{3_5}} loc" onclick="click_control(this,3,5)"></td>
                 <td id="3_6"  class="{{3_6}} loc" onclick="click_control(this,3,6)"></td>
-                <td id="3_6"  class="{{3_7}} loc" onclick="click_control(this,3,7)"></td>
+                <td id="3_7"  class="{{3_7}} loc" onclick="click_control(this,3,7)"></td>
                 <td id="3_8"  class="{{3_8}} loc" onclick="click_control(this,3,8)"></td>
                 <td id="3_9"  class="{{3_9}} loc" onclick="click_control(this,3,9)"></td>
                 <td id="3_10" class="{{3_10}} loc" onclick="click_control(this,3,10)"></td>
@@ -301,7 +301,7 @@ function selecVert() {
                 <td id="4_4" class="{{4_4}} loc" onclick="click_control(this,4,4)"></td>
                 <td id="4_5" class="{{4_5}} loc" onclick="click_control(this,4,5)"></td>
                 <td id="4_6" class="{{4_6}} loc" onclick="click_control(this,4,6)"></td>
-                <td id="4_6" class="{{4_7}} loc" onclick="click_control(this,4,7)"></td>
+                <td id="4_7" class="{{4_7}} loc" onclick="click_control(this,4,7)"></td>
                 <td id="4_8"  class="{{4_8}} loc" onclick="click_control(this,4,8)"></td>
                 <td id="4_9" class="{{4_9}} loc" onclick="click_control(this,4,9)"></td>
                 <td id="4_10"  class="{{4_10}} loc" onclick="click_control(this,4,10)"></td>
@@ -313,7 +313,7 @@ function selecVert() {
                 <td id="5_4" class="{{5_4}} loc" onclick="click_control(this,5,4)"></td>
                 <td id="5_5" class="{{5_5}} loc" onclick="click_control(this,5,5)"></td>
                 <td id="5_6" class="{{5_6}} loc" onclick="click_control(this,5,6)"></td>
-                <td id="5_6" class="{{5_7}} loc" onclick="click_control(this,5,7)"></td>
+                <td id="5_7" class="{{5_7}} loc" onclick="click_control(this,5,7)"></td>
                 <td id="5_8" class="{{5_8}} loc" onclick="click_control(this,5,8)"></td>
                 <td id="5_9" class="{{5_9}} loc" onclick="click_control(this,5,10)"></td>
                 <td id="5_10" class="{{5_10}} loc" onclick="click_control(this,5,10)"></td>
@@ -325,7 +325,7 @@ function selecVert() {
                 <td id="6_4" class="{{6_4}} loc" onclick="click_control(this,6,4)"></td>
                 <td id="6_5" class="{{6_5}} loc" onclick="click_control(this,6,5)"></td>
                 <td id="6_6" class="{{6_6}} loc" onclick="click_control(this,6,6)"></td>
-                <td id="6_6" class="{{6_7}} loc" onclick="click_control(this,6,7)"></td>
+                <td id="6_7" class="{{6_7}} loc" onclick="click_control(this,6,7)"></td>
                 <td id="6_8" class="{{6_8}} loc" onclick="click_control(this,6,8)"></td>
                 <td id="6_9" class="{{6_9}} loc" onclick="click_control(this,6,10)"></td>
                 <td id="6_10" class="{{6_10}} loc" onclick="click_control(this,6,10)"></td>
@@ -337,7 +337,7 @@ function selecVert() {
                 <td id="7_4" class="{{7_4}} loc" onclick="click_control(this,7,4)"></td>
                 <td id="7_5" class="{{7_5}} loc" onclick="click_control(this,7,5)"></td>
                 <td id="7_6" class="{{7_6}} loc" onclick="click_control(this,7,6)"></td>
-                <td id="7_6" class="{{7_7}} loc" onclick="click_control(this,7,7)"></td>
+                <td id="7_7" class="{{7_7}} loc" onclick="click_control(this,7,7)"></td>
                 <td id="7_8" class="{{7_8}} loc" onclick="click_control(this,7,8)"></td>
                 <td id="7_9" class="{{7_9}} loc" onclick="click_control(this,7,10)"></td>
                 <td id="7_10" class="{{7_10}} loc" onclick="click_control(this,7,10)"></td>
@@ -349,7 +349,7 @@ function selecVert() {
                 <td id="8_4" class="{{7_4}} loc" onclick="click_control(this,8,4)"></td>
                 <td id="8_5" class="{{7_5}} loc" onclick="click_control(this,8,5)"></td>
                 <td id="8_6" class="{{7_6}} loc" onclick="click_control(this,8,6)"></td>
-                <td id="8_6" class="{{7_7}} loc" onclick="click_control(this,8,7)"></td>
+                <td id="8_7" class="{{7_7}} loc" onclick="click_control(this,8,7)"></td>
                 <td id="8_8" class="{{7_8}} loc" onclick="click_control(this,8,8)"></td>
                 <td id="8_9" class="{{7_9}} loc" onclick="click_control(this,8,10)"></td>
                 <td id="8_10" class="{{7_10}} loc" onclick="click_control(this,8,10)"></td>
@@ -361,7 +361,7 @@ function selecVert() {
                 <td id="9_4" class="{{7_4}} loc" onclick="click_control(this,9,4)"></td>
                 <td id="9_5" class="{{7_5}} loc" onclick="click_control(this,9,5)"></td>
                 <td id="9_6" class="{{7_6}} loc" onclick="click_control(this,9,6)"></td>
-                <td id="9_6" class="{{7_7}} loc" onclick="click_control(this,9,7)"></td>
+                <td id="9_7" class="{{7_7}} loc" onclick="click_control(this,9,7)"></td>
                 <td id="9_8" class="{{7_8}} loc" onclick="click_control(this,9,8)"></td>
                 <td id="9_9" class="{{7_9}} loc" onclick="click_control(this,9,9)"></td>
                 <td id="9_10" class="{{7_10}} loc" onclick="click_control(this,9,10)"></td>
@@ -373,7 +373,7 @@ function selecVert() {
                 <td id="10_4" class="{{7_4}} loc" onclick="click_control(this,10,4)"></td>
                 <td id="10_5" class="{{7_5}} loc" onclick="click_control(this,10,5)"></td>
                 <td id="10_6" class="{{7_6}} loc" onclick="click_control(this,10,6)"></td>
-                <td id="10_6" class="{{7_7}} loc" onclick="click_control(this,10,7)"></td>
+                <td id="10_7" class="{{7_7}} loc" onclick="click_control(this,10,7)"></td>
                 <td id="10_8" class="{{7_8}} loc" onclick="click_control(this,10,8)"></td>
                 <td id="10_9" class="{{7_9}} loc" onclick="click_control(this,10,9)"></td>
                 <td id="10_10" class="{{7_10}} loc" onclick="click_control(this,10,10)"></td>


### PR DESCRIPTION
addresses this issue: https://github.com/OSU-CS361-W17/group21_project2/issues/22

Also addresses: https://github.com/OSU-CS361-W17/group21_project2/issues/8

Some of the columns were named identically which caused double firing/placement. This resolves the bug by renaming the double named columns.